### PR TITLE
Frontend 22

### DIFF
--- a/website/src/api/index.js
+++ b/website/src/api/index.js
@@ -5,7 +5,7 @@ const api = axios.create({
   withCredentials: true,
 });
 
-const getToken = () => JSON.parse(localStorage.getItem("tokens"));
+const getToken = () => JSON.parse(localStorage.getItem("token"));
 
 //---------------------User APIs---------------------
 

--- a/website/src/app/PrivateRoute.js
+++ b/website/src/app/PrivateRoute.js
@@ -1,5 +1,6 @@
-import React, { useContext } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import { Route, Redirect } from "react-router-dom";
+import { getUserInfo } from "../api";
 import { useAuth } from "../context/auth";
 import { UserContext } from "../context/UserContext";
 
@@ -15,10 +16,10 @@ function PrivateRoute({ component: Component, ...rest }) {
         user.token ? (
           <Component {...props} />
         ) : (
-          <Redirect
-            to={{ pathname: "/login", state: { referrer: props.location } }}
-          />
-        )
+            <Redirect
+              to={{ pathname: "/login", state: { referrer: props.location } }}
+            />
+          )
       }
     />
   );

--- a/website/src/app/PrivateRoute.js
+++ b/website/src/app/PrivateRoute.js
@@ -1,15 +1,18 @@
-import React from "react";
+import React, { useContext } from "react";
 import { Route, Redirect } from "react-router-dom";
 import { useAuth } from "../context/auth";
+import { UserContext } from "../context/UserContext";
 
 function PrivateRoute({ component: Component, ...rest }) {
-  const { authTokens } = useAuth();
+  // const { authTokens } = useAuth();
+
+  const [user, setUser] = useContext(UserContext);
 
   return (
     <Route
       {...rest}
       render={(props) =>
-        authTokens ? (
+        user.token ? (
           <Component {...props} />
         ) : (
           <Redirect

--- a/website/src/app/index.js
+++ b/website/src/app/index.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import {
   FAQ,
   Home,
@@ -17,18 +17,14 @@ import PrivateRoute from "./PrivateRoute";
 import { AuthContext } from "../context/auth";
 import { theme } from "./GlobalTheme";
 import PostRegistration from "../pages/Register/postRegistration/PostRegistration";
+import { UserContext, UserProvider } from '../context/UserContext';
+import { getUserInfo } from "../api";
 
 function App() {
-  const existingTokens = JSON.parse(localStorage.getItem("tokens"));
-  const [authTokens, setAuthTokens] = useState(existingTokens);
 
-  const setTokens = (data) => {
-    localStorage.setItem("tokens", JSON.stringify(data));
-    setAuthTokens(data);
-  };
 
   return (
-    <AuthContext.Provider value={{ authTokens, setAuthTokens: setTokens }}>
+    <UserProvider>
       <Router>
         <ThemeProvider theme={theme}>
           <CssBaseline />
@@ -51,7 +47,7 @@ function App() {
           </Switch>
         </ThemeProvider>
       </Router>
-    </AuthContext.Provider>
+    </UserProvider>
   );
 }
 

--- a/website/src/components/Layout/AppMenu.js
+++ b/website/src/components/Layout/AppMenu.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useContext } from "react";
 import styled from "styled-components";
 import LogoNavBar from "../../images/LogoNavBar.png";
 import userIcon from "../../images/user.svg";
@@ -6,7 +6,7 @@ import backIcon from "../../images/backIcon.svg";
 
 import { Divider, MenuItem, Menu } from "@material-ui/core";
 import { Link } from "react-router-dom";
-import { useAuth } from "../../context/auth";
+import { UserContext } from '../../context/UserContext';
 
 const Wrapper = styled.section`
   display: flex;
@@ -75,12 +75,11 @@ const MenuLink = styled(Link)`
 
 const DropDownMenu = (props) => {
   const pathname = window.location.pathname;
-  const { authTokens, setAuthTokens } = useAuth();
+  const [user, setUser] = useContext(UserContext);
 
   function logOut() {
-    setAuthTokens("");
-    localStorage.removeItem("userType");
-    localStorage.removeItem("userId");
+    setUser({});
+    localStorage.removeItem("token");
   }
 
   return (
@@ -101,7 +100,7 @@ const DropDownMenu = (props) => {
         onClose={props.handleClose}
       >
         {/* {props.registrationMenu ? ( */}
-        {authTokens == "" ? (
+        {user.token == "" ? (
           <div>
             <MenuLink to="/">
               <MenuItem onClick={props.handleClose}>About</MenuItem>

--- a/website/src/context/UserContext.js
+++ b/website/src/context/UserContext.js
@@ -1,41 +1,51 @@
 import React, { useEffect, useState, createContext } from 'react';
-
+import { withRouter } from "react-router-dom";
 import { getUserInfo } from '../api';
 
 export const UserContext = createContext();
 
 export const UserProvider = (props) => {
-    
-    const [user, setUser] = useState({
-        _id: '',
-        registrationComplete: '',
-        role: '',
-        userType: ''
-    });
 
-    useEffect(() => {
+  const [user, setUser] = useState({
+    _id: '',
+    registrationComplete: '',
+    role: '',
+    userType: '',
+    token: ''
+  });
+  const [loading, setLoading] = useState(true);
 
-        const token = localStorage.getItem('token');
-        if(token) {
-          getUserInfo({})
-            .then((response) => {
-              setUser({
-                _id: response.data.user._id,
-                registrationComplete: response.data.user.registrationComplete,
-                role: response.data.user.role,
-                userType: response.data.user.userType
-              });
-            })
-            .catch((err) => {
-              console.log(err);
-            })
-        }
-    
-      }, []);
+  useEffect(() => {
+    const token = localStorage.getItem('token');
+    if (token) {
+      getUserInfo({})
+        .then((response) => {
+          setUser({
+            _id: response.data.user._id,
+            registrationComplete: response.data.user.registrationComplete,
+            role: response.data.user.role,
+            userType: response.data.user.userType,
+            token: token
+          });
+          setLoading(false);
+        })
+        .catch((err) => {
+          console.log(err);
+          setLoading(false);
+        })
+    } else {
+      setLoading(false);
+    }
 
-    return (
+  }, []);
+
+  return (
+    <>
+      {!loading &&
         <UserContext.Provider value={[user, setUser]}>
-            {props.children}
+          {props.children}
         </UserContext.Provider>
-    )
+      }
+    </>
+  )
 };

--- a/website/src/context/UserContext.js
+++ b/website/src/context/UserContext.js
@@ -1,0 +1,41 @@
+import React, { useEffect, useState, createContext } from 'react';
+
+import { getUserInfo } from '../api';
+
+export const UserContext = createContext();
+
+export const UserProvider = (props) => {
+    
+    const [user, setUser] = useState({
+        _id: '',
+        registrationComplete: '',
+        role: '',
+        userType: ''
+    });
+
+    useEffect(() => {
+
+        const token = localStorage.getItem('token');
+        if(token) {
+          getUserInfo({})
+            .then((response) => {
+              setUser({
+                _id: response.data.user._id,
+                registrationComplete: response.data.user.registrationComplete,
+                role: response.data.user.role,
+                userType: response.data.user.userType
+              });
+            })
+            .catch((err) => {
+              console.log(err);
+            })
+        }
+    
+      }, []);
+
+    return (
+        <UserContext.Provider value={[user, setUser]}>
+            {props.children}
+        </UserContext.Provider>
+    )
+};

--- a/website/src/pages/LoginPage.js
+++ b/website/src/pages/LoginPage.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useContext } from "react";
 import { Redirect } from "react-router-dom";
 import { Container, Title, Menu } from "../components";
 import Button from "@material-ui/core/Button";
@@ -9,6 +9,7 @@ import { LinkedIn } from "react-linkedin-login-oauth2";
 
 import { loginUser } from "../api";
 import { useAuth } from "../context/auth";
+import { UserContext } from "../context/UserContext";
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -35,8 +36,9 @@ const Login = (props) => {
   const classes = useStyles();
   const [isLoggedIn, setLoggedIn] = useState(false);
   const [isError, setIsError] = useState(false);
+  const [user, setUser] = useContext(UserContext);
 
-  const { setAuthTokens } = useAuth();
+  // const { setAuthTokens } = useAuth();
 
   // store the page where user wanted to go and redirect to that page after login
   const referrer = props.location.state
@@ -50,9 +52,12 @@ const Login = (props) => {
     })
       .then((response) => {
         if (response.data.success) {
-          localStorage.setItem("userId", response.data.user._id);
-          localStorage.setItem("userType", response.data.user.userType);
-          setAuthTokens(response.data.token);
+          setUser({
+            userId: response.data._id,
+            userType: response.data.userType,
+            token: response.data.token
+          });
+          localStorage.setItem('token', JSON.stringify(response.data.token));
           setLoggedIn(true);
           // redirect to matches for now
         } else {

--- a/website/src/pages/LoginPage.js
+++ b/website/src/pages/LoginPage.js
@@ -10,7 +10,6 @@ import { LinkedIn } from "react-linkedin-login-oauth2";
 import { loginUser } from "../api";
 import { useAuth } from "../context/auth";
 import { UserContext } from "../context/UserContext";
-
 const useStyles = makeStyles((theme) => ({
   root: {
     marginBottom: "1em",
@@ -34,18 +33,17 @@ const Wrapper = styled.div`
 
 const Login = (props) => {
   const classes = useStyles();
-  const [isLoggedIn, setLoggedIn] = useState(false);
   const [isError, setIsError] = useState(false);
   const [user, setUser] = useContext(UserContext);
 
   // const { setAuthTokens } = useAuth();
 
   // store the page where user wanted to go and redirect to that page after login
-  const referrer = props.location.state
+  const referrer = props.location.state && props.location.referrer != "/login"
     ? props.location.state.referrer
-    : "/postRegistration";
-  // const referrer = '/';
+    : "/sessions";
 
+  console.log(referrer);
   const handleSuccess = (data) => {
     loginUser({
       authCode: data.code,
@@ -53,13 +51,11 @@ const Login = (props) => {
       .then((response) => {
         if (response.data.success) {
           setUser({
-            userId: response.data._id,
-            userType: response.data.userType,
+            _id: response.data.user._id,
+            userType: response.data.user.userType,
             token: response.data.token
           });
           localStorage.setItem('token', JSON.stringify(response.data.token));
-          setLoggedIn(true);
-          // redirect to matches for now
         } else {
           setIsError(true);
         }
@@ -74,7 +70,7 @@ const Login = (props) => {
     setIsError(true);
   };
 
-  if (isLoggedIn) {
+  if (user.token) {
     return <Redirect to={referrer} />;
   }
 

--- a/website/src/pages/Matches/MatchCard.js
+++ b/website/src/pages/Matches/MatchCard.js
@@ -66,7 +66,6 @@ const MatchCard = ({
   currentMatches,
   isMentor,
 }) => {
-  console.log("currentMatches", currentMatches);
   const classes = useStyles();
   function handleClick(id) {
     setShowProfile();
@@ -82,12 +81,9 @@ const MatchCard = ({
   );
 
   if (selectedProfile && showProfile) {
-    console.log("selectedProfile", selectedProfile);
     return <MatchProfile selectedProfile={selectedProfile} />;
   }
-  console.log("currentMatches", currentMatches);
   //we need a way to show specific text for mentee and mentor users : put a isMentor variable in the API data
-  console.log("isMentor = ", isMentor);
   return (
     <div>
       {isMentor == "mentor" ? (

--- a/website/src/pages/Matches/Matches.js
+++ b/website/src/pages/Matches/Matches.js
@@ -32,7 +32,6 @@ export default function Matches() {
     getUserMatches({ _id: user._id })
       .then((res) => {
         setMatchData(res.data.matches);
-        console.log("res.data", res.data);
         setCurrentMatches(res.data.matches.pending);
       })
       .catch((err) => console.log(err));

--- a/website/src/pages/Matches/Matches.js
+++ b/website/src/pages/Matches/Matches.js
@@ -1,10 +1,11 @@
-import React, { useState, useEffect } from "react";
+import React, { useContext, useState, useEffect, useCon } from "react";
 import Card from "./MatchCard";
 import Profile from "./MatchProfile";
 import CardType from "./CardType";
 import styled from "styled-components";
 import { Menu } from "../../components";
 import { getUserMatches } from "../../api";
+import { UserContext } from "../../context/UserContext";
 
 const Container = styled.div`
   margin-left: 16px;
@@ -24,17 +25,15 @@ export default function Matches() {
     closed: [],
   });
   const [currentMatches, setCurrentMatches] = useState([]);
-  const [isMentor, setIsMentor] = useState([]);
+  const [user, setUser] = useContext(UserContext);
 
   //Load matches API
   useEffect(() => {
-    const APP_ID = localStorage.getItem("userId");
-    getUserMatches({ _id: APP_ID })
+    getUserMatches({ _id: user._id })
       .then((res) => {
         setMatchData(res.data.matches);
         console.log("res.data", res.data);
         setCurrentMatches(res.data.matches.pending);
-        setIsMentor(res.data.userType);
       })
       .catch((err) => console.log(err));
   }, []);

--- a/website/src/pages/Register/RegisterMain.js
+++ b/website/src/pages/Register/RegisterMain.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useContext, useState } from "react";
 import { Container, Title, Menu } from "../../components";
 import Button from "@material-ui/core/Button";
 import styled from "styled-components";
@@ -9,6 +9,7 @@ import { LinkedIn } from "react-linkedin-login-oauth2";
 import { registerUser } from "../../api";
 import RegisterStep1 from "./RegisterStep1";
 import { useAuth } from "../../context/auth";
+import { UserContext } from "../../context/UserContext";
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -33,6 +34,9 @@ const Wrapper = styled.div`
 
 const RegisterMain = (props) => {
   const classes = useStyles();
+
+  const [user, setUser] = useContext(UserContext);
+
   const [showUserFields, setShowUserFields] = useState(false);
   const [firstName, setFirstName] = useState("");
   const [email, setEmail] = useState("");
@@ -41,7 +45,7 @@ const RegisterMain = (props) => {
   const [bio, setBio] = useState("");
   const [linkedInId, setLinkedInId] = useState("");
 
-  const { setAuthTokens } = useAuth();
+
 
   const continueStep = (e) => {
     registerUser({
@@ -56,9 +60,12 @@ const RegisterMain = (props) => {
       },
     })
       .then((response) => {
-        localStorage.setItem("userId", response.data.user._id);
-        localStorage.setItem("userType", response.data.user.userType);
-        setAuthTokens(response.data.token);
+        setUser({
+          userId: response.data._id,
+          userType: response.data.userType,
+          token: response.data.token
+        });
+        localStorage.setItem('token', response.data.token);
         props.handleNext();
       })
       .catch((error) => {

--- a/website/src/pages/Register/RegisterMain.js
+++ b/website/src/pages/Register/RegisterMain.js
@@ -61,11 +61,11 @@ const RegisterMain = (props) => {
     })
       .then((response) => {
         setUser({
-          userId: response.data._id,
+          _id: response.data._id,
           userType: response.data.userType,
           token: response.data.token
         });
-        localStorage.setItem('token', response.data.token);
+        localStorage.setItem('token', JSON.stringify(response.data.token));
         props.handleNext();
       })
       .catch((error) => {

--- a/website/src/pages/Register/RegisterStep5.js
+++ b/website/src/pages/Register/RegisterStep5.js
@@ -1,11 +1,12 @@
-import React from "react";
-import { Container, DotStepper, Title, TitleWrapper } from "../../components";
-import { updateUser } from "../../api";
-
+import React, {useContext} from "react";
 import { InputLabel, TextField } from "@material-ui/core";
 
+import { Container, DotStepper, Title, TitleWrapper } from "../../components";
+import { updateUser } from "../../api";
+import { UserContext } from '../../context/UserContext';
+
 const RegisterStep5 = (props) => {
-  const userId = localStorage.getItem("userId");
+  const [user, setUser] = useContext(UserContext);
 
   const months = [
     "January",
@@ -33,7 +34,7 @@ const RegisterStep5 = (props) => {
 
   function handleUpdateUser() {
     updateUser({
-      _id: userId,
+      _id: user._id,
       register: true,
       user: {
         userType: props.values.userType,

--- a/website/src/pages/Register/postRegistration/PostRegistration.jsx
+++ b/website/src/pages/Register/postRegistration/PostRegistration.jsx
@@ -1,6 +1,6 @@
 import React, { useContext, useState } from "react";
 import axios from "axios";
-import { withRouter } from "react-router-dom";
+import { Redirect, withRouter } from "react-router-dom";
 
 import {
   Button,
@@ -35,7 +35,6 @@ const PostRegistration = (props) => {
 
   const [signUpResult, setSignUpResult] = useState(null);
   const [user, setUser] = useContext(UserContext);
-  const [userData, setUserData] = useState(this.props.data);
 
   const userContinue = () => {
     updateUser({
@@ -46,7 +45,6 @@ const PostRegistration = (props) => {
     })
       .then((response) => {
         setSignUpResult('CONTINUE')
-        this.props.history.push("/sessions");
       })
       .catch((error) => {
         console.log(error);
@@ -59,19 +57,24 @@ const PostRegistration = (props) => {
 
   const renderComponent = (param) => {
     switch (param) {
+      // Commenting for now but might need to use this once we implement email verification
+      // case 'CONTINUE':
+      //   return (
+      //     <Wrapper>
+      //       <AirplanePicture />
+      //       <ConfirmationTitle>
+      //         An email confirmation is on its way.
+      //     </ConfirmationTitle>
+      //       <ConfirmationText>
+      //         Thanks for joining OpenMentorshop. We’re excited for you to gain
+      //         success in your career.
+      //     </ConfirmationText>
+      //     </Wrapper>
+      //   )
       case 'CONTINUE':
         return (
-          <Wrapper>
-            <AirplanePicture />
-            <ConfirmationTitle>
-              An email confirmation is on its way.
-          </ConfirmationTitle>
-            <ConfirmationText>
-              Thanks for joining OpenMentorshop. We’re excited for you to gain
-              success in your career.
-          </ConfirmationText>
-          </Wrapper>
-        )
+          <Redirect to='/sessions'/>
+        );
 
       case 'WAIT':
         return (
@@ -164,4 +167,4 @@ const PostRegistration = (props) => {
   );
 }
 
-export default withRouter(PostRegistration);
+export default PostRegistration;

--- a/website/src/pages/Register/postRegistration/PostRegistration.jsx
+++ b/website/src/pages/Register/postRegistration/PostRegistration.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import React, { useContext, useState } from "react";
 import axios from "axios";
 import { withRouter } from "react-router-dom";
 
@@ -29,25 +29,23 @@ import {
 import { Container, TitleWrapper, Title } from "../../../components";
 
 import { updateUser } from "../../../api";
+import { UserContext } from "../../../context/UserContext";
 
-class PostRegistration extends Component {
-  constructor(props) {
-    super(props);
-    this.state = { userData: this.props.data, signUpResult: null };
-    this.userId = localStorage.getItem("userId");
-    this.userContinue = this.userContinue.bind(this);
-    this.userWait = this.userWait.bind(this);
-  }
+const PostRegistration = (props) => {
 
-  userContinue() {
+  const [signUpResult, setSignUpResult] = useState(null);
+  const [user, setUser] = useContext(UserContext);
+  const [userData, setUserData] = useState(this.props.data);
+
+  const userContinue = () => {
     updateUser({
-      _id: this.userId,
+      _id: user._id,
       user: {
         active: true,
       },
     })
       .then((response) => {
-        this.setState({ signUpResult: "CONTINUE" });
+        setSignUpResult('CONTINUE')
         this.props.history.push("/sessions");
       })
       .catch((error) => {
@@ -55,103 +53,115 @@ class PostRegistration extends Component {
       });
   }
 
-  userWait() {
-    this.setState({ signUpResult: "WAIT" });
+  const userWait = () => {
+    setSignUpResult('WAIT')
   }
-  render() {
-    return {
-      CONTINUE: (
-        <Wrapper>
-          <AirplanePicture />
-          <ConfirmationTitle>
-            An email confirmation is on its way.
-          </ConfirmationTitle>
-          <ConfirmationText>
-            Thanks for joining OpenMentorshop. We’re excited for you to gain
-            success in your career.
-          </ConfirmationText>
-        </Wrapper>
-      ),
-      WAIT: (
-        <Wrapper>
-          <ThumbsUpPicture />
-          <WaitTitle>
-            No problem! We’ll hold your information until you’re ready.
-          </WaitTitle>
-          <WaitText>
-            Just sign back in and indicate that you’re ready for the mentorship
-            session.
-          </WaitText>
-        </Wrapper>
-      ),
-      null: (
-        <Container>
+
+  const renderComponent = (param) => {
+    switch (param) {
+      case 'CONTINUE':
+        return (
           <Wrapper>
-            <TitleWrapper>
-              <Title>Thanks for signing up with Open Mentorship!</Title>
-            </TitleWrapper>
-            <BodyText>
-              Please read through these steps, and indicate whether you want to
-              continue with the process or wait until you’re ready for a
-              matching session.
-            </BodyText>
-
-            <ContentWrapper>
-              <PictureTextWrapper>
-                <MailPicture />
-                <PictureText>
-                  You will recieve an email confirmation of your application.
-                </PictureText>
-              </PictureTextWrapper>
-
-              <PictureTextWrapper>
-                <HumansPicture alt="" />
-                <PictureText>
-                  Within one week, you will recieve a curated list of mentors to
-                  choose from.
-                </PictureText>
-              </PictureTextWrapper>
-
-              <PictureTextWrapper>
-                <PenPaperPicture alt="" />
-                <PictureText>
-                  You will have one week from the day you recieve the list to
-                  message each of your top choices, explaining why you want to
-                  work with them.
-                </PictureText>
-              </PictureTextWrapper>
-
-              <PictureTextWrapper>
-                <MagnifyPicture alt="" />
-                <PictureText>
-                  After that period, the mentors will recieve their requests,
-                  and will have one week to decide on who they want to work
-                  with.
-                </PictureText>
-              </PictureTextWrapper>
-
-              <PictureTextWrapper>
-                <HandShakePicture alt="" />
-                <PictureText>
-                  When a match is made, you will have a set amount of time that
-                  your session will last. Make it count!
-                </PictureText>
-              </PictureTextWrapper>
-            </ContentWrapper>
-
-            <ButtonWrapper>
-              <Button onClick={this.userContinue}>
-                <ButtonText>I'm In!</ButtonText>
-              </Button>
-              <Button wait onClick={this.userWait}>
-                <ButtonText wait>I'm going to wait.</ButtonText>
-              </Button>
-            </ButtonWrapper>
+            <AirplanePicture />
+            <ConfirmationTitle>
+              An email confirmation is on its way.
+          </ConfirmationTitle>
+            <ConfirmationText>
+              Thanks for joining OpenMentorshop. We’re excited for you to gain
+              success in your career.
+          </ConfirmationText>
           </Wrapper>
-        </Container>
-      ),
-    }[this.state.signUpResult];
+        )
+
+      case 'WAIT':
+        return (
+          <Wrapper>
+            <ThumbsUpPicture />
+            <WaitTitle>
+              No problem! We’ll hold your information until you’re ready.
+              </WaitTitle>
+            <WaitText>
+              Just sign back in and indicate that you’re ready for the mentorship
+              session.
+              </WaitText>
+          </Wrapper>
+        )
+
+      default:
+        return (
+          <Container>
+            <Wrapper>
+              <TitleWrapper>
+                <Title>Thanks for signing up with Open Mentorship!</Title>
+              </TitleWrapper>
+              <BodyText>
+                Please read through these steps, and indicate whether you want to
+                continue with the process or wait until you’re ready for a
+                matching session.
+                </BodyText>
+
+              <ContentWrapper>
+                <PictureTextWrapper>
+                  <MailPicture />
+                  <PictureText>
+                    You will recieve an email confirmation of your application.
+                    </PictureText>
+                </PictureTextWrapper>
+
+                <PictureTextWrapper>
+                  <HumansPicture alt="" />
+                  <PictureText>
+                    Within one week, you will recieve a curated list of mentors to
+                    choose from.
+                    </PictureText>
+                </PictureTextWrapper>
+
+                <PictureTextWrapper>
+                  <PenPaperPicture alt="" />
+                  <PictureText>
+                    You will have one week from the day you recieve the list to
+                    message each of your top choices, explaining why you want to
+                    work with them.
+                    </PictureText>
+                </PictureTextWrapper>
+
+                <PictureTextWrapper>
+                  <MagnifyPicture alt="" />
+                  <PictureText>
+                    After that period, the mentors will recieve their requests,
+                    and will have one week to decide on who they want to work
+                    with.
+                    </PictureText>
+                </PictureTextWrapper>
+
+                <PictureTextWrapper>
+                  <HandShakePicture alt="" />
+                  <PictureText>
+                    When a match is made, you will have a set amount of time that
+                    your session will last. Make it count!
+                    </PictureText>
+                </PictureTextWrapper>
+              </ContentWrapper>
+
+              <ButtonWrapper>
+                <Button onClick={userContinue}>
+                  <ButtonText>I'm In!</ButtonText>
+                </Button>
+                <Button wait onClick={userWait}>
+                  <ButtonText wait>I'm going to wait.</ButtonText>
+                </Button>
+              </ButtonWrapper>
+            </Wrapper>
+          </Container>
+        )
+    }
   }
+
+  return (
+    <div>
+      {renderComponent(signUpResult)}
+    </div>
+  );
 }
 
 export default withRouter(PostRegistration);


### PR DESCRIPTION
Revamped state management on the frontend. Replaced auth context with user context which stores user info such as _id, role, userType, token. To use this user context on any page, use the useContext method to get the user and setUser methods. See /matches for example.

For now, the way it works is, it checks if we have a token in localStorage and if exists, the userContext page gets user info from our API and updates the userContext. The access token is set to a very long expiry time for now but in a future update, we need to store refresh tokens and have a very small expiry for the access tokens