### PR TITLE
Linkedin redirect uri must come from env variable

### DIFF
--- a/website_v2/src/components/landing/linkedin_main.tsx
+++ b/website_v2/src/components/landing/linkedin_main.tsx
@@ -9,9 +9,7 @@ import {signIn} from "next-auth/react";
 const Linkedin = () => {
   const {linkedInLogin} = useLinkedIn({
     clientId: process.env.NEXT_PUBLIC_LINKEDIN_CLIENT_ID!,
-    redirectUri: `${
-      typeof window === "object" && window.location.origin
-    }/linkedin`,
+    redirectUri: process.env.NEXT_PUBLIC_LINKEDIN_REDIRECT_URI!,
     scope: "r_emailaddress r_liteprofile",
     onSuccess: code => {
       signIn("credentials", {authCode: code});


### PR DESCRIPTION
For allowing local developement and dev. domain to work with the same backend dev server, the redirect uri must come from the env variables