### PR TITLE
Fix the isLocal check for login API

### DIFF
--- a/website_v2/src/endpoints/user.ts
+++ b/website_v2/src/endpoints/user.ts
@@ -26,7 +26,7 @@ const nextAuthLogin = async (
       headers: headerProvider(),
       body: JSON.stringify({
         authCode: credentials?.authCode,
-        isLocal: Boolean(process.env.NEXT_APP_IS_LOCAL),
+        isLocal: process.env.NEXT_APP_IS_LOCAL?.toLowerCase() === "true",
       }),
     });
     return res;


### PR DESCRIPTION
Fix the isLocal check for the Login API. Env variables are retutned as strings and equality is a good way to check the boolean value